### PR TITLE
docker-compose.yml - change image for Divolte

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
 
   # Divolte container
   divolte:
-    image: divolte/divolte-collector
+    image: divthis/divolte
     environment:
       DIVOLTE_KAFKA_BROKER_LIST: kafka:9092
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
   divolte:
     image: divthis/divolte
     environment:
+      DIVOLTE_KAFKA_ENABLED: true
       DIVOLTE_KAFKA_BROKER_LIST: kafka:9092
     ports:
       - 8290:8290


### PR DESCRIPTION
Chahge Docker image for Divolte service because the old image is absent in the DockerHub repository.